### PR TITLE
fix compile error in generic TDM codec

### DIFF
--- a/patches/drivers/ti/mcasp/0001-ASoC-add-generic-TDM-codec.patch
+++ b/patches/drivers/ti/mcasp/0001-ASoC-add-generic-TDM-codec.patch
@@ -1,21 +1,21 @@
-From c91761fab292fe91583b9b597d431d088d123336 Mon Sep 17 00:00:00 2001
+From 91cf06d33c5eb019b1fbecd411bcaaf9f497b788 Mon Sep 17 00:00:00 2001
 From: Matthijs van Duin <matthijsvanduin@gmail.com>
 Date: Mon, 1 Feb 2016 08:21:08 +0100
-Subject: [PATCH 1/2] ASoC: add generic TDM codec
+Subject: [PATCH] ASoC: add generic TDM codec
 
 Signed-off-by: Matthijs van Duin <matthijsvanduin@gmail.com>
 ---
  sound/soc/codecs/Kconfig  |   4 ++
  sound/soc/codecs/Makefile |   2 +
- sound/soc/codecs/tdm.c    | 110 ++++++++++++++++++++++++++++++++++++++++++++++
- 3 files changed, 116 insertions(+)
+ sound/soc/codecs/tdm.c    | 112 ++++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 118 insertions(+)
  create mode 100644 sound/soc/codecs/tdm.c
 
 diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
-index cfdafc4..917cc40 100644
+index c67667bb970f..0f40b095ddb8 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
-@@ -112,6 +112,7 @@ config SND_SOC_ALL_CODECS
+@@ -135,6 +135,7 @@ config SND_SOC_ALL_CODECS
  	select SND_SOC_TAS5086 if I2C
  	select SND_SOC_TAS571X if I2C
  	select SND_SOC_TAS5720 if I2C
@@ -23,7 +23,7 @@ index cfdafc4..917cc40 100644
  	select SND_SOC_TFA9879 if I2C
  	select SND_SOC_TLV320AIC23_I2C if I2C
  	select SND_SOC_TLV320AIC23_SPI if SPI_MASTER
-@@ -656,6 +657,9 @@ config SND_SOC_TAS5720
+@@ -812,6 +813,9 @@ config SND_SOC_TAS5720
  	  Enable support for Texas Instruments TAS5720L/M high-efficiency mono
  	  Class-D audio power amplifiers.
  
@@ -34,10 +34,10 @@ index cfdafc4..917cc40 100644
  	tristate "NXP Semiconductors TFA9879 amplifier"
  	depends on I2C
 diff --git a/sound/soc/codecs/Makefile b/sound/soc/codecs/Makefile
-index f632fc4..a47d48d 100644
+index 958cd4912fbc..ea82c79333ea 100644
 --- a/sound/soc/codecs/Makefile
 +++ b/sound/soc/codecs/Makefile
-@@ -115,6 +115,7 @@ snd-soc-sti-sas-objs := sti-sas.o
+@@ -142,6 +142,7 @@ snd-soc-sti-sas-objs := sti-sas.o
  snd-soc-tas5086-objs := tas5086.o
  snd-soc-tas571x-objs := tas571x.o
  snd-soc-tas5720-objs := tas5720.o
@@ -45,7 +45,7 @@ index f632fc4..a47d48d 100644
  snd-soc-tfa9879-objs := tfa9879.o
  snd-soc-tlv320aic23-objs := tlv320aic23.o
  snd-soc-tlv320aic23-i2c-objs := tlv320aic23-i2c.o
-@@ -307,6 +308,7 @@ obj-$(CONFIG_SND_SOC_TAS2552)	+= snd-soc-tas2552.o
+@@ -363,6 +364,7 @@ obj-$(CONFIG_SND_SOC_TAS2552)	+= snd-soc-tas2552.o
  obj-$(CONFIG_SND_SOC_TAS5086)	+= snd-soc-tas5086.o
  obj-$(CONFIG_SND_SOC_TAS571X)	+= snd-soc-tas571x.o
  obj-$(CONFIG_SND_SOC_TAS5720)	+= snd-soc-tas5720.o
@@ -55,10 +55,10 @@ index f632fc4..a47d48d 100644
  obj-$(CONFIG_SND_SOC_TLV320AIC23_I2C)	+= snd-soc-tlv320aic23-i2c.o
 diff --git a/sound/soc/codecs/tdm.c b/sound/soc/codecs/tdm.c
 new file mode 100644
-index 0000000..f20d3e2
+index 000000000000..b8fb3b8d0177
 --- /dev/null
 +++ b/sound/soc/codecs/tdm.c
-@@ -0,0 +1,110 @@
+@@ -0,0 +1,112 @@
 +/*
 + * ALSA SoC generic TDM codec driver
 + *
@@ -110,10 +110,12 @@ index 0000000..f20d3e2
 +};
 +
 +static struct snd_soc_codec_driver soc_codec_tdm_audio = {
-+	.dapm_widgets = tdm_audio_widgets,
-+	.num_dapm_widgets = ARRAY_SIZE(tdm_audio_widgets),
-+	.dapm_routes = tdm_audio_routes,
-+	.num_dapm_routes = ARRAY_SIZE(tdm_audio_routes),
++	.component_driver = {
++		.dapm_widgets		= tdm_audio_widgets,
++		.num_dapm_widgets	= ARRAY_SIZE(tdm_audio_widgets),
++		.dapm_routes		= tdm_audio_routes,
++		.num_dapm_routes	= ARRAY_SIZE(tdm_audio_routes),
++	},
 +};
 +
 +static struct snd_soc_dai_driver tdm_audio_dai = {
@@ -170,5 +172,5 @@ index 0000000..f20d3e2
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS("platform:" DRV_NAME);
 -- 
-2.6.4
+2.10.2
 


### PR DESCRIPTION
Small fix to prevent compile error. The cause was this change:

```
commit 8073aefa60823acf205a1e6a5ea118297179d766
Author: Kuninori Morimoto <kuninori.morimoto.gx@renesas.com>
Date:   Mon Aug 8 09:36:49 2016 +0000

    ASoC: remove codec duplicated callback function
```