### PR TITLE
fix Version field in packages to show actual version of kernel

### DIFF
--- a/build_deb.sh
+++ b/build_deb.sh
@@ -77,7 +77,7 @@ make_deb () {
 	build_opts="${build_opts} KBUILD_DEBARCH=${DEBARCH}"
 	build_opts="${build_opts} LOCALVERSION=${BUILD}"
 	build_opts="${build_opts} KDEB_CHANGELOG_DIST=${deb_distro}"
-	build_opts="${build_opts} KDEB_PKGVERSION=1${DISTRO}"
+	build_opts="${build_opts} KDEB_PKGVERSION=${KERNEL_TAG}${BUILD}"
 	#Just use "linux-upstream"...
 	#https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/scripts/package/builddeb?id=3716001bcb7f5822382ac1f2f54226b87312cc6b
 	build_opts="${build_opts} KDEB_SOURCENAME=linux-upstream"


### PR DESCRIPTION
`1xross` is interpreted by apt as version 1, this means if it has a version 4 kernel available elsewhere it will install that instead of this 5.8 version.