### PR TITLE
drivers: misc: mikrobus add support for alternate Click ID EEPROM

### DIFF
--- a/patches/drivers/mikrobus/0003-drivers-misc-mikrobus-add-support-alternate-Click-ID.patch
+++ b/patches/drivers/mikrobus/0003-drivers-misc-mikrobus-add-support-alternate-Click-ID.patch
@@ -1,0 +1,343 @@
+From 3363f1da1dc7fb5c3926051ab9dc6d05d7c83334 Mon Sep 17 00:00:00 2001
+From: vaishnav98 <vaishnav@beagleboard.org>
+Date: Tue, 23 Nov 2021 12:24:04 +0530
+Subject: [PATCH] drivers: misc: mikrobus add support alternate Click ID EEPROM
+
+Add support for Alternate Click ID EEPROM Part No. DS28E36
+
+Signed-off-by: vaishnav <vaishnav@beagleboard.org>
+---
+ drivers/misc/mikrobus/mikrobus_core.c |  31 +----
+ drivers/misc/mikrobus/mikrobus_id.c   | 171 +++++++++++++++-----------
+ 2 files changed, 103 insertions(+), 99 deletions(-)
+
+diff --git a/drivers/misc/mikrobus/mikrobus_core.c b/drivers/misc/mikrobus/mikrobus_core.c
+index 5700396b83e4..c4511bc2846c 100644
+--- a/drivers/misc/mikrobus/mikrobus_core.c
++++ b/drivers/misc/mikrobus/mikrobus_core.c
+@@ -78,7 +78,7 @@ int mikrobus_port_scan_eeprom(struct mikrobus_port *port)
+ 	if (retval != 1) {
+ 		dev_err(&port->dev, "failed to fetch manifest start address %d\n",
+ 			retval);
+-		return -EINVAL;
++		header[0] = 0;
+ 	}
+ 	manifest_start_addr = header[0] << 8;
+ 	pr_info("manifest start address is 0x%x \n", manifest_start_addr);
+@@ -255,7 +255,7 @@ int mikrobus_port_pinctrl_select(struct mikrobus_port *port)
+ 						port->pinctrl_selected[i]);
+ 		if (!IS_ERR(state)) {
+ 			retval = pinctrl_select_state(port->pinctrl, state);
+-			pr_info("setting pinctrl %s\n",
++			pr_debug("setting pinctrl %s\n",
+ 					port->pinctrl_selected[i]);
+ 			if (retval != 0) {
+ 				dev_err(&port->dev, "failed to select state %s\n",
+@@ -400,26 +400,6 @@ static void mikrobus_board_device_release_all(struct addon_board_info *info)
+ 	}
+ }
+ 
+-static struct software_node *software_node_alloc(const struct property_entry *properties)
+-{
+-	struct property_entry *props;
+-	struct software_node *node;
+-
+-	props = property_entries_dup(properties);
+-	if (IS_ERR(props))
+-		return ERR_CAST(props);
+-
+-	node = kzalloc(sizeof(*node), GFP_KERNEL);
+-	if (!node) {
+-		property_entries_free(props);
+-		return ERR_PTR(-ENOMEM);
+-	}
+-
+-	node->properties = props;
+-
+-	return node;
+-}
+-
+ static int mikrobus_device_register(struct mikrobus_port *port,
+ 					struct board_device_info *dev, char *board_name)
+ {
+@@ -515,7 +495,7 @@ static int mikrobus_device_register(struct mikrobus_port *port,
+ 		if (dev->irq)
+ 			i2c->irq = mikrobus_irq_get(port, dev->irq, dev->irq_type);
+ 		if (dev->properties)
+-			i2c->swnode = software_node_alloc(dev->properties);
++			i2c->fwnode = fwnode_create_software_node(dev->properties, NULL);
+ 		i2c->addr = dev->reg;
+ 		dev->dev_client = (void *) i2c_new_client_device(port->i2c_adap, i2c);
+ 		break;
+@@ -625,7 +605,6 @@ static int mikrobus_port_id_eeprom_probe(struct mikrobus_port *port)
+ 	char devname[MIKROBUS_NAME_SIZE];
+ 	char drvname[MIKROBUS_NAME_SIZE] = "w1-gpio";
+ 	int retval;
+-	int i;
+ 
+ 	mikrobus_id_eeprom_w1_device = kzalloc(sizeof(*mikrobus_id_eeprom_w1_device), GFP_KERNEL);
+ 	if (!mikrobus_id_eeprom_w1_device)
+@@ -773,7 +752,7 @@ int mikrobus_port_gb_register(struct gbphy_host *host, void *manifest_blob, size
+ 	struct gb_connection *spi_connection;
+ 	struct gb_gpio_controller *ggc;
+ 	struct mikrobus_port *port;
+-	struct gpio_desc *desc;
++	// struct gpio_desc *desc;
+ 	struct gpio_descs *descs;
+ 	int retval;
+ 
+@@ -827,7 +806,7 @@ int mikrobus_port_gb_register(struct gbphy_host *host, void *manifest_blob, size
+ 	INIT_LIST_HEAD(&board->devices);
+ 	retval = mikrobus_manifest_parse(board, manifest_blob, manifest_size);
+ 	if (!retval) {
+-		dev_err(&port->dev, "failed to parse manifest, size %lu\n",
++		dev_err(&port->dev, "failed to parse manifest, size %u\n",
+ 			manifest_size);
+ 		retval = -EINVAL;
+ 		goto err_free_board;
+diff --git a/drivers/misc/mikrobus/mikrobus_id.c b/drivers/misc/mikrobus/mikrobus_id.c
+index 2b97342327d9..d8e9b3660b6b 100644
+--- a/drivers/misc/mikrobus/mikrobus_id.c
++++ b/drivers/misc/mikrobus/mikrobus_id.c
+@@ -16,18 +16,19 @@
+ 
+ #include <linux/mikrobus.h>
+ 
++#define W1_EEPROM_MIKROBUS_SECONDARY_ID	0x4C
+ #define W1_EEPROM_MIKROBUS_ID	0x43
+-
+-#define W1_MIKROBUS_ID_EEPROM_SIZE	0x0A00
++#define W1_MIKROBUS_ID_EEPROM_SIZE	 0x0A00
++#define W1_MIKROBUS_ID_EEPROM_SECONDARY_SIZE	 0x0200
++#define W1_MIKROBUS_ID_EEPROM_SECONDARY_PAGE_SIZE	32
+ #define W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE	32
+ #define W1_MIKROBUS_ID_EEPROM_VERIFY_SCRATCH_SIZE	35
+ #define W1_MIKROBUS_ID_READ_EEPROM	0xF0
++#define W1_MIKROBUS_ID_READ_SECONDARY_EEPROM 0x69
++#define W1_MIKROBUS_ID_RELEASE_SECONDARY_EEPROM 0xAA
+ #define W1_MIKROBUS_ID_EEPROM_READ_RETRIES	10
+-#define W1_MIKROBUS_ID_EEPROM_WRITE_RETRIES	5
+-#define W1_MIKROBUS_ID_EEPROM_WRITE_SCRATCH	0x0F
+-#define W1_MIKROBUS_ID_EEPROM_READ_SCRATCH	0xAA
+-#define W1_MIKROBUS_ID_EEPROM_COPY_SCRATCH	0x55
+ #define W1_MIKROBUS_ID_EEPROM_TPROG_MS		20
++#define MIKROBUS_ID_USER_EEPROM_ADDR	0x0A0A
+ 
+ static int w1_mikrobus_id_readblock(struct w1_slave *sl, int off, int count, char *buf)
+ {
+@@ -64,90 +65,80 @@ static int w1_mikrobus_id_readblock(struct w1_slave *sl, int off, int count, cha
+ 	return -EIO;
+ }
+ 
+-static int w1_mikrobus_id_movescratch(struct w1_slave *sl, int addr, char *buf)
++static int w1_mikrobus_id_readpage_secondary(struct w1_slave *sl, int pageaddr, char *buf)
+ {
+-	u8 wrbuf[4];
+-	u8 scratchpad_verify[W1_MIKROBUS_ID_EEPROM_VERIFY_SCRATCH_SIZE];
+-	u8 TA1, TA2, ES;
+-	int verify_status;
+-	int tries;
+-
+-	wrbuf[0] = W1_MIKROBUS_ID_EEPROM_WRITE_SCRATCH;
+-	wrbuf[1] = addr & 0xFF;
+-	wrbuf[2] = addr >> 8;
++	u8 crc_rdbuf[2];
+ 
+-	tries = W1_MIKROBUS_ID_EEPROM_WRITE_RETRIES;
+-	do {
+-		if (w1_reset_select_slave(sl))
+-			return -1;
+-		w1_write_block(sl->master, wrbuf, 3);
+-		w1_write_block(sl->master, buf, W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE);
+-		if (w1_reset_select_slave(sl))
+-			return -1;
+-		w1_write_8(sl->master, W1_MIKROBUS_ID_EEPROM_READ_SCRATCH);
+-		TA1 = w1_read_8(sl->master);
+-		TA2 = w1_read_8(sl->master);
+-		ES = w1_read_8(sl->master);
+-		w1_read_block(sl->master, scratchpad_verify, W1_MIKROBUS_ID_EEPROM_VERIFY_SCRATCH_SIZE);
+-		verify_status = memcmp(buf, scratchpad_verify, W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE);
+-	} while(verify_status && --tries);
+-
+-	if(!tries && verify_status){
+-		dev_err(&sl->dev, "verify scratchpad failed %d times\n",
+-			W1_MIKROBUS_ID_EEPROM_WRITE_RETRIES);
+-		return -EIO;
+-	}
+-		
+-	wrbuf[0] = W1_MIKROBUS_ID_EEPROM_COPY_SCRATCH;
+-	wrbuf[1] = addr & 0xFF;
+-	wrbuf[2] = addr >> 8;
+-	wrbuf[3] = ES;
+ 	if (w1_reset_select_slave(sl))
+-			return -1;
+-	w1_write_block(sl->master, wrbuf, 4);
+-	msleep(W1_MIKROBUS_ID_EEPROM_TPROG_MS);
++				return -1;
++	w1_write_8(sl->master, W1_MIKROBUS_ID_READ_SECONDARY_EEPROM);
++	w1_write_8(sl->master, pageaddr);
++	w1_read_block(sl->master, crc_rdbuf, 2);
++	w1_write_8(sl->master, W1_MIKROBUS_ID_RELEASE_SECONDARY_EEPROM);
++	msleep(10);
++	w1_read_block(sl->master, crc_rdbuf, 1);
++	w1_read_block(sl->master, buf, W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE);
++	w1_read_block(sl->master, crc_rdbuf, 2);
+ 	return 0;
+ }
+ 
+-static int w1_mikrobus_id_writeblock(struct w1_slave *sl, int off, int count, char *buf)
++static int w1_mikrobus_id_readbuf_secondary(struct w1_slave *sl, int count, char *buf)
+ {
+-	u16 wraddr = 0;
+-	u16 len = count - (count % W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE);
+-	u8 scratchpad_write[W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE] = {0};
+-
+-	while(len > 0) {
+-		w1_mikrobus_id_movescratch(sl, wraddr + off, buf + wraddr);
+-		wraddr += W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE;
+-		len -= W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE;
++	u8 pageaddr = 0;
++	int iter, index, ret;
++	int	len = count - (count % W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE);
++	u8 temp_rdbuf[W1_MIKROBUS_ID_EEPROM_SECONDARY_PAGE_SIZE];
++
++	while(len > 0) {			
++			ret = w1_mikrobus_id_readpage_secondary(sl, pageaddr, buf + (W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE*pageaddr));
++			pageaddr += 1;
++			len -= W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE;
+ 	}
+ 
+ 	if(count % W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE){
+-		memcpy(scratchpad_write, buf + wraddr, count % W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE);
+-		w1_mikrobus_id_movescratch(sl, wraddr + off, scratchpad_write);
++			ret = w1_mikrobus_id_readpage_secondary(sl, pageaddr, temp_rdbuf);
++			for(iter = W1_MIKROBUS_ID_EEPROM_SCRATCH_SIZE*pageaddr, index=0; iter < count; iter++, index++)
++				buf[iter] = temp_rdbuf[index];
+ 	}
+-
+-	return 0;
++	return ret;
+ }
+ 
+-static int w1_mikrobus_id_nvmem_read(void *priv, unsigned int off, void *buf, size_t count)
++static int w1_mikrobus_id_readblock_secondary(struct w1_slave *sl, int off, int count, char *buf)
+ {
+-	struct w1_slave *sl = priv;
+-	int ret;
++	u8 *cmp;
++	int tries = W1_MIKROBUS_ID_EEPROM_READ_RETRIES;
+ 
+-	mutex_lock(&sl->master->bus_mutex);
+-	ret = w1_mikrobus_id_readblock(sl, off, count, buf);
+-	mutex_unlock(&sl->master->bus_mutex);
+-	
+-	return ret;
++	if(off == MIKROBUS_ID_USER_EEPROM_ADDR && count == 1) {
++		buf[0] = 0;
++		return 0;
++	}
++
++	do {	
++		w1_mikrobus_id_readbuf_secondary(sl, count, buf);
++		cmp = kzalloc(count, GFP_KERNEL);
++		if (!cmp)
++			return -ENOMEM;		
++		w1_mikrobus_id_readbuf_secondary(sl, count, cmp);
++		if (!memcmp(cmp, buf, count)){
++			kfree(cmp);
++			return 0;
++		}
++	} while (--tries);
++
++	kfree(cmp);
++	return -EINVAL;
+ }
+ 
+-static int w1_mikrobus_id_nvmem_write(void *priv, unsigned int off, void *buf, size_t count)
++static int w1_mikrobus_id_nvmem_read(void *priv, unsigned int off, void *buf, size_t count)
+ {
+ 	struct w1_slave *sl = priv;
+ 	int ret;
+ 
+ 	mutex_lock(&sl->master->bus_mutex);
+-	ret = w1_mikrobus_id_writeblock(sl, off, count, buf);
++	if (sl->family->fid == W1_EEPROM_MIKROBUS_SECONDARY_ID)
++		ret = w1_mikrobus_id_readblock_secondary(sl, off, count, buf);
++	else
++		ret = w1_mikrobus_id_readblock(sl, off, count, buf);
+ 	mutex_unlock(&sl->master->bus_mutex);
+ 	
+ 	return ret;
+@@ -160,12 +151,12 @@ static int w1_mikrobus_id_add_slave(struct w1_slave *sl)
+ 	struct nvmem_config nvmem_cfg = {
+ 		.dev = &sl->dev,
+ 		.reg_read = w1_mikrobus_id_nvmem_read,
+-		.reg_write = w1_mikrobus_id_nvmem_write,
+ 		.type = NVMEM_TYPE_EEPROM,
+-		.read_only = false,
++		.read_only = true,
+ 		.word_size = 1,
+ 		.stride = 1,
+-		.size = W1_MIKROBUS_ID_EEPROM_SIZE,
++		.size = (sl->family->fid == W1_EEPROM_MIKROBUS_SECONDARY_ID) ? 
++		 W1_MIKROBUS_ID_EEPROM_SECONDARY_SIZE: W1_MIKROBUS_ID_EEPROM_SIZE,
+ 		.priv = sl,
+ 	};
+ 
+@@ -181,7 +172,7 @@ static int w1_mikrobus_id_add_slave(struct w1_slave *sl)
+ 	return PTR_ERR_OR_ZERO(nvmem);
+ }
+ 
+-static const struct w1_family_ops w1_family_mikrobus_id_fops = {
++static struct w1_family_ops w1_family_mikrobus_id_fops = {
+ 	.add_slave		= w1_mikrobus_id_add_slave,
+ };
+ 
+@@ -189,9 +180,43 @@ static struct w1_family w1_family_mikrobus_id = {
+ 	.fid = W1_EEPROM_MIKROBUS_ID,
+ 	.fops = &w1_family_mikrobus_id_fops,
+ };
+-module_w1_family(w1_family_mikrobus_id);
++
++static struct w1_family w1_family_mikrobus_id_alternate = {
++	.fid = W1_EEPROM_MIKROBUS_SECONDARY_ID,
++	.fops = &w1_family_mikrobus_id_fops,
++};
++
++static int __init w1_mikrobusid_init(void)
++{
++	int err;
++
++	err = w1_register_family(&w1_family_mikrobus_id);
++	if (err)
++		return err;
++
++	err = w1_register_family(&w1_family_mikrobus_id_alternate);
++	if (err)
++		goto err_mikrobusidinit;
++
++
++	return 0;
++
++err_mikrobusidinit:
++	w1_unregister_family(&w1_family_mikrobus_id);
++	return err;
++}
++
++static void __exit w1_mikrobusid_exit(void)
++{
++	w1_unregister_family(&w1_family_mikrobus_id);
++	w1_unregister_family(&w1_family_mikrobus_id_alternate);
++}
++
++module_init(w1_mikrobusid_init);
++module_exit(w1_mikrobusid_exit);
+ 
+ MODULE_AUTHOR("Vaishnav M A <vaishnav@beagleboard.org>");
+ MODULE_DESCRIPTION("w1 family ac driver for mikroBUS ID EEPROM");
+ MODULE_LICENSE("GPL");
+ MODULE_ALIAS("w1-family-" __stringify(W1_EEPROM_MIKROBUS_ID));
++MODULE_ALIAS("w1-family-" __stringify(W1_EEPROM_MIKROBUS_SECONDARY_ID));
+-- 
+2.25.1
+


### PR DESCRIPTION
Hi @RobertCNelson ,
The following patch adds support for alternate mikroBUS click ID EEPROM, Part No. DS28E36 in addition to the original Click ID 1Wire EEPROM DS28EC20, the changes have been tested(with overlay changes) on v5.15 kernel, needs update in overlay to resolve the pinmux conflict(UART4 and PWM), please let me know what is the best way to fix this(currently mikroBUS driver probe fails when failing to set the pinmux state)

Test Log ( DS28EC20): 
```
debian@beaglebone:~$ uname -a
Linux beaglebone 5.15.2-bone9 #1xross PREEMPT Sun Nov 21 00:10:01 IST 2021 armv7l GNU/Linux
debian@beaglebone:~$ cat /etc/dogtag 
BeagleBoard.org Debian Buster IoT mikroBUS Image 2021-10-29
debian@beaglebone:~$ dmesg |grep -e mikrobus -e wire
[    1.735820] Driver for 1-wire Dallas network protocol.
[    2.129544] mikrobus:mikrobus_port_register: registering port mikrobus-0 
[    2.129767] mikrobus mikrobus-0: mikrobus port 0 eeprom empty probing default eeprom
[    2.198785] w1_master_driver w1_bus_master1: Attaching one wire slave 43.0000017b5366 crc bd
[    2.259216] mikrobus:mikrobus_port_scan_eeprom: manifest start address is 0x0 
[    3.156290] mikrobus_manifest:mikrobus_manifest_attach_device: parsed device 1, driver=fb_ssd1306, protocol=11, reg=0
[    3.156341] mikrobus_manifest:mikrobus_manifest_attach_device: device 1, number of properties=5
[    3.156370] mikrobus_manifest:mikrobus_manifest_attach_device: device 1, number of gpio resource=2
[    3.156382] mikrobus_manifest:mikrobus_manifest_parse:  OLEDB Click manifest parsed with 1 devices
[    3.156487] mikrobus mikrobus-0: registering device : fb_ssd1306
[    3.156506] mikrobus mikrobus-0:  adding lookup table : spi0.0
debian@beaglebone:~$ 
```
Test Log ( DS28E36): 
```

debian@beaglebone:~$ uname -a
Linux beaglebone 5.15.2-bone9 #1xross PREEMPT Sun Nov 21 00:10:01 IST 2021 armv7l GNU/Linux
debian@beaglebone:~$ cat /etc/dogtag 
BeagleBoard.org Debian Buster IoT mikroBUS Image 2021-10-29
debian@beaglebone:~$ dmesg |grep -e mikrobus -e wire
[    1.736600] Driver for 1-wire Dallas network protocol.
[    2.129824] mikrobus:mikrobus_port_register: registering port mikrobus-0 
[    2.130048] mikrobus mikrobus-0: mikrobus port 0 eeprom empty probing default eeprom
[    2.198814] w1_master_driver w1_bus_master1: Attaching one wire slave 4c.0000000fdd8f crc 24
[    2.233081] mikrobus:mikrobus_port_scan_eeprom: manifest start address is 0x0 
[    4.432397] mikrobus_manifest:mikrobus_manifest_attach_device: parsed device 1, driver=fb_ssd1351, protocol=11, reg=0
[    4.432444] mikrobus_manifest:mikrobus_manifest_attach_device: device 1, number of properties=7
[    4.432469] mikrobus_manifest:mikrobus_manifest_attach_device: device 1, number of gpio resource=2
[    4.432482] mikrobus_manifest:mikrobus_manifest_parse:  OLEDC Click manifest parsed with 1 devices
[    4.432577] mikrobus mikrobus-0: registering device : fb_ssd1351
[    4.432596] mikrobus mikrobus-0:  adding lookup table : spi0.0
debian@beaglebone:~$ 
```